### PR TITLE
Add Tornado example with GlobusLoginHandler

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Contents:
    introduction
    django
    flask
+   tornado
    native_cli_apps
    wordpress
    drupal

--- a/docs/tornado.rst
+++ b/docs/tornado.rst
@@ -172,7 +172,7 @@ The web app can be run behind an reverse proxy server. If you use Debian-based s
         ProxyPass / http://127.0.0.1:8888/
         ProxyPassReverse / http://127.0.0.1:8888/
 
-After restarting the Apache server, the application should be accessible at https://&lt;your_server_host_name&gt;/.
+After restarting the Apache server, the application should be accessible at https://<your_server_host_name>/.
 
 .. _Tornado: https://tornadoweb.org/
 .. _Django: https://djangoproject.com/

--- a/docs/tornado.rst
+++ b/docs/tornado.rst
@@ -172,7 +172,7 @@ The web app can be run behind an reverse proxy server. If you use Debian-based s
         ProxyPass / http://127.0.0.1:8888/
         ProxyPassReverse / http://127.0.0.1:8888/
 
-After restarting the Apache server, the application should be accessible at https://<your_server_host_name>/.
+After restarting the Apache server, the application should be accessible at https://&lt;your_server_host_name&gt;/.
 
 .. _Tornado: https://tornadoweb.org/
 .. _Django: https://djangoproject.com/

--- a/docs/tornado.rst
+++ b/docs/tornado.rst
@@ -1,13 +1,13 @@
 Tornado
 ======
 
-Tornado is a Python web framework and asynchronous networking library. 
+`Tornado`_ is a Python web framework and asynchronous networking library. 
 Request handlers in Tornado web applications that take advantage of 
 non-blocking network I/O, have to be implemented in a certain way, 
 different than in web apps built based on frameworks like `Django`_ or `Flask`_.
-This section shows how to build a simple Tornado web app with Globus login handler. 
-The Globus login handler extends `tornado.auth.OAuth2Mixin` class that was changed in Tornado version 6.
-If you need to use Tornado version 5, please check out the corresponding handler and example at 
+This section shows how to create a simple Tornado web app with a Globus login handler. 
+The Globus login handler extends ``tornado.auth.OAuth2Mixin`` class from Tornado version 6. 
+If you need to use an older version of Tornado, please check out the corresponding handler and example at 
 `tornado_v5 <https://github.com/globusonline/globus-integration-examples/tree/master/src/tornado/tornado_v5/>`_
 
 Develop web app
@@ -23,9 +23,9 @@ First, we will create a virtual environment named ``venv``, activate it to run o
 
 
 We will start developing the web app from the minimal `hello world <https://www.tornadoweb.org/en/stable/guide/structure.html>`_ example 
-from the official Tornado documnetation, and will be changing it step by step. 
-First, we will extend `MainHandler` to show `Login` and Logout` links, and, when a user is logged in (`user_id` cookie set), 
-display information about the user. We will use the Tornado template (which we will save in `home.html`):
+on the official Tornado documentation, and will be modifying it to add Globus OAuth2 authentication. 
+First, we will extend the ``MainHandler`` to show ``Login`` and ``Logout`` links, and, when a user is logged in which means ``user_id`` cookie set, 
+display information about the user. To do this, we will use the Tornado template (``home.html``):
 
 .. code-block:: html
 
@@ -58,8 +58,8 @@ display information about the user. We will use the Tornado template (which we w
     </body>
     </html>
 
-The template shows user's information and `Logout` link when `user_id` is defined, and shows `Login to Globus` link otherwise. 
-The MainHandler will extract user's information from cookies, that the app sets in the authentication process, and render the template.
+The template shows user's information and ``Logout`` link when ``user_id`` is defined, and shows ``Login to Globus`` link otherwise. 
+The ``MainHandler`` will extract user's information from cookies, that the app sets in the authentication process, and render the template.
 
 .. code-block:: python
 
@@ -77,7 +77,7 @@ The MainHandler will extract user's information from cookies, that the app sets 
                         access_token=self.get_secure_cookie("access_token"),
                         refresh_token=self.get_secure_cookie("refresh_token"))
 
-When a user logs out, the `user_id` cookie must be cleared. We will do it in the `LogoutHandler`:
+When a user logs out, the ``user_id`` cookie must be cleared. We will do it in the ``LogoutHandler``:
 
 .. code-block:: python
 
@@ -86,7 +86,7 @@ When a user logs out, the `user_id` cookie must be cleared. We will do it in the
             self.clear_cookie("user_id")
             self.redirect("/")
 
-The request from a user's web browser generated when the user click the `Login` link and the OAuth2 flow 
+The request from a user's web browser generated when the user click the ``Login`` link and the OAuth2 flow 
 will be handled by a separate class:
 
 .. code-block:: python
@@ -117,16 +117,16 @@ will be handled by a separate class:
                     response_type="code",
                     extra_params={"access_type": "offline"})
 
-When a user clicks the `Login` link, the `authorized_redirect()` function in the `else` block is called. 
+When a user clicks the ``Login`` link, the ``authorized_redirect()`` function in the ``else`` block is called. 
 The functions is defined in one of the supper classes. The function redirects the user's web browser to Globus Auth. 
 Once the user authenticates to Globus Auth, the user's web browser is redirected back to the web app. 
-The redirection response comes with the `code` parameter set. The parameter is detected by `get_argument()` function. 
-In the subsequent lines, the `code` is exchanged to access tokens, then one of the access tokens is used to get a user info, 
-and the access tokens and user information are saved in cookies. Functions `get_tokens()` and `get_user_info()` are specific 
-to Globus Auth and have to be implemented in a subclass of tornado.auth.OAuth2Mixin, 
+The redirection response comes with the ``code`` parameter set. The parameter is detected by ``get_argument()`` function. 
+In the subsequent lines, the ``code`` is exchanged to access tokens, then one of the access tokens is used to get a user info, 
+and the access tokens and user information are saved in cookies. Functions ``get_tokens()`` and ``get_user_info()`` are specific 
+to Globus Auth and have to be implemented in a subclass of ``tornado.auth.OAuth2Mixin``, 
 `GlobusOAuth2Mixin class <https://github.com/globusonline/globus-integration-examples/tree/master/src/tornado/globus.py/>`_.
 
-Once we have all handlers implemented, we have to tie them with URLs: `/`, `/login`, `/logout`. To do it, We will modify `make_app()`:
+Once we have all handlers implemented, we have to tie them with URLs: ``/``, ``/login``, ``/logout``. To do it, We will modify ``make_app()``:
 
 .. code-block:: python
 
@@ -153,8 +153,8 @@ Once we have all handlers implemented, we have to tie them with URLs: `/`, `/log
         ]
         return tornado.web.Application(handlers, **settings)
 
-To get OAuth2 client id and secret that you have to provide in `settings`, register this web app on 
-https://developers.globus.org with `https://<your_server_host_name>/login` as a redirect URL.
+To get OAuth2 client id and secret that you have to provide in ``settings``, register this web app on 
+https://developers.globus.org with ``https://<your_server_host_name>/login`` as a redirect URL.
 
 After all of the changes are made, you can run the app:
 

--- a/docs/tornado.rst
+++ b/docs/tornado.rst
@@ -1,0 +1,181 @@
+Tornado
+======
+
+Tornado is a Python web framework and asynchronous networking library. 
+Request handlers in Tornado web applications that take advantage of 
+non-blocking network I/O, have to be implemented in a certain way, 
+different than in web apps built based on frameworks like `Django`_ or `Flask`_.
+This section shows how to build a simple Tornado web app with Globus login handler. 
+The Globus login handler extends `tornado.auth.OAuth2Mixin` class that was changed in Tornado version 6.
+If you need to use Tornado version 5, please check out the corresponding handler and example at 
+`tornado_v5 <https://github.com/globusonline/globus-integration-examples/tree/master/src/tornado/tornado_v5/>`_
+
+Develop web app
+------------------------
+
+First, we will create a virtual environment named ``venv``, activate it to run our web application in the environment and install Tornado:
+
+.. code-block:: bash
+
+   $ python3 -m venv venv
+   $ . venv/bin/activate
+   $ pip install tornado
+
+
+We will start developing the web app from the minimal `hello world <https://www.tornadoweb.org/en/stable/guide/structure.html>`_ example 
+from the official Tornado documnetation, and will be changing it step by step. 
+First, we will extend `MainHandler` to show `Login` and Logout` links, and, when a user is logged in (`user_id` cookie set), 
+display information about the user. We will use the Tornado template (which we will save in `home.html`):
+
+.. code-block:: html
+
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Tornado Web App</title>
+    </head>
+    <body>
+        <div>
+        <h1>Tornado web app with authentication delegated to Globus Auth</h1>
+        <p>
+             <br/>
+        {% if user_id %}
+            Hello {{ name }}!<br/>
+            &nbsp; Username: {{ username }}<br/>
+            &nbsp; Email: {{ email }}<br/>
+            &nbsp; UUID: {{ user_id }}<br/>
+            &nbsp; Organization: {{ organization }}<br/>
+            &nbsp; Access token: {{ access_token }}<br/>
+            &nbsp; Refresh token: {{ refresh_token }}<br/>
+            <br/>
+            <a href="/logout">Logout</a>
+        {% else %}
+            <a href="/login">Login to Globus</a>
+        {% end %}
+        </p>
+        </div>
+    </body>
+    </html>
+
+The template shows user's information and `Logout` link when `user_id` is defined, and shows `Login to Globus` link otherwise. 
+The MainHandler will extract user's information from cookies, that the app sets in the authentication process, and render the template.
+
+.. code-block:: python
+
+    class MainHandler(tornado.web.RequestHandler):
+        def get_current_user(self):
+            return self.get_secure_cookie("user_id")
+    
+        def get(self):
+            self.render("home.html",
+                        user_id=self.current_user,
+                        username=self.get_secure_cookie("username"),
+                        email=self.get_secure_cookie("email"),
+                        name=self.get_secure_cookie("name"),
+                        organization=self.get_secure_cookie("organization"),
+                        access_token=self.get_secure_cookie("access_token"),
+                        refresh_token=self.get_secure_cookie("refresh_token"))
+
+When a user logs out, the `user_id` cookie must be cleared. We will do it in the `LogoutHandler`:
+
+.. code-block:: python
+
+    class LogoutHandler(tornado.web.RequestHandler):
+        async def get(self):
+            self.clear_cookie("user_id")
+            self.redirect("/")
+
+The request from a user's web browser generated when the user click the `Login` link and the OAuth2 flow 
+will be handled by a separate class:
+
+.. code-block:: python
+
+    class GlobusOAuth2LoginHandler(tornado.web.RequestHandler,
+                                   globus.GlobusOAuth2Mixin):
+        async def get(self):
+            if self.get_argument("code", False):
+                tokens = await self.get_tokens(
+                    redirect_uri=self.settings["globus_oauth"]["redirect_uri"],
+                    code=self.get_argument("code"))
+                expires_at = int(time.time()) + tokens["expires_in"]
+                user_info = await self.get_user_info(tokens["access_token"])
+                # Save the user with e.g. set_secure_cookie
+                self.set_secure_cookie("user_id", user_info["sub"], expires=expires_at-60)
+                self.set_secure_cookie("username", user_info["preferred_username"])
+                self.set_secure_cookie("email", user_info["email"])
+                self.set_secure_cookie("name", user_info["name"])
+                self.set_secure_cookie("organization", user_info["organization"])
+                self.set_secure_cookie("access_token", tokens["access_token"])
+                self.set_secure_cookie("refresh_token", tokens["refresh_token"])
+                self.redirect("/")
+            else:
+                self.authorize_redirect(
+                    redirect_uri=self.settings["globus_oauth"]["redirect_uri"],
+                    client_id=self.settings["globus_oauth"]["key"],
+                    scope=self.settings["globus_oauth"]["scope"],
+                    response_type="code",
+                    extra_params={"access_type": "offline"})
+
+When a user clicks the `Login` link, the `authorized_redirect()` function in the `else` block is called. 
+The functions is defined in one of the supper classes. The function redirects the user's web browser to Globus Auth. 
+Once the user authenticates to Globus Auth, the user's web browser is redirected back to the web app. 
+The redirection response comes with the `code` parameter set. The parameter is detected by `get_argument()` function. 
+In the subsequent lines, the `code` is exchanged to access tokens, then one of the access tokens is used to get a user info, 
+and the access tokens and user information are saved in cookies. Functions `get_tokens()` and `get_user_info()` are specific 
+to Globus Auth and have to be implemented in a subclass of tornado.auth.OAuth2Mixin, 
+`GlobusOAuth2Mixin class <https://github.com/globusonline/globus-integration-examples/tree/master/src/tornado/globus.py/>`_.
+
+Once we have all handlers implemented, we have to tie them with URLs: `/`, `/login`, `/logout`. To do it, We will modify `make_app()`:
+
+.. code-block:: python
+
+    def make_app():
+        settings = {
+            "cookie_secret": "32oETzKXQAGaYdkL5gEmGeJJFuYh7EQnp2XdTP1o/Vo=",
+            "xsrf_cookies": True,
+            "globus_oauth": {
+                "key": "<Globus_OAuth2_Client_Id>",
+                "secret": "<Globus_OAuth2_Client_Secret>",
+                "redirect_uri": "https://<your_server_host_name>/login",
+                "scope": [
+                    "openid",
+                    "profile",
+                    "email",
+                    "urn:globus:auth:scope:transfer.api.globus.org:all"
+                ]
+            }
+        }
+        handlers = [
+            (r"/", MainHandler),
+            (r"/login", GlobusOAuth2LoginHandler),
+            (r"/logout", LogoutHandler),
+        ]
+        return tornado.web.Application(handlers, **settings)
+
+To get OAuth2 client id and secret that you have to provide in `settings`, register this web app on 
+https://developers.globus.org with `https://<your_server_host_name>/login` as a redirect URL.
+
+After all of the changes are made, you can run the app:
+
+.. code-block:: bash
+
+   $ python -m tornado.autoreload app.py
+
+Configure Apache server
+-----------------------
+
+The web app can be run behind an reverse proxy server. If you use Debian-based system, for example Ubuntu, add the following lines to ``/etc/apache2/sites-available/default-ssl.conf`` in ``<VirtualHost _default_:443>`` section
+
+.. code-block:: apache
+
+        ProxyPass / http://127.0.0.1:8888/
+        ProxyPassReverse / http://127.0.0.1:8888/
+
+After restarting the Apache server, the application should be accessible at https://<your_server_host_name>/.
+
+.. _Tornado: https://tornadoweb.org/
+.. _Django: https://djangoproject.com/
+.. _Flask: http://flask.pocoo.org/
+
+

--- a/docs/tornado.rst
+++ b/docs/tornado.rst
@@ -86,8 +86,8 @@ When a user logs out, the ``user_id`` cookie must be cleared. We will do it in t
             self.clear_cookie("user_id")
             self.redirect("/")
 
-The request from a user's web browser generated when the user click the ``Login`` link and the OAuth2 flow 
-will be handled by a separate class:
+Other remaining URLs and requests that our app must respond to are the ``Login`` URL and the OAuth2 flow requests.
+We will handle them in one class:
 
 .. code-block:: python
 
@@ -118,15 +118,15 @@ will be handled by a separate class:
                     extra_params={"access_type": "offline"})
 
 When a user clicks the ``Login`` link, the ``authorized_redirect()`` function in the ``else`` block is called. 
-The functions is defined in one of the supper classes. The function redirects the user's web browser to Globus Auth. 
+The function is defined in one of the super classes. The function redirects the user's web browser to Globus Auth. 
 Once the user authenticates to Globus Auth, the user's web browser is redirected back to the web app. 
 The redirection response comes with the ``code`` parameter set. The parameter is detected by ``get_argument()`` function. 
-In the subsequent lines, the ``code`` is exchanged to access tokens, then one of the access tokens is used to get a user info, 
-and the access tokens and user information are saved in cookies. Functions ``get_tokens()`` and ``get_user_info()`` are specific 
-to Globus Auth and have to be implemented in a subclass of ``tornado.auth.OAuth2Mixin``, 
+The subsequent lines exchange the ``code`` to access tokens, then use one of the access tokens to get a user info, 
+and save the access tokens and user information in cookies. The functions that obtain the tokens, ``get_tokens()``, 
+and user info, ``get_user_info()``, are specific  to Globus Auth and have to be implemented in a subclass of ``tornado.auth.OAuth2Mixin``, 
 `GlobusOAuth2Mixin class <https://github.com/globusonline/globus-integration-examples/tree/master/src/tornado/globus.py/>`_.
 
-Once we have all handlers implemented, we have to tie them with URLs: ``/``, ``/login``, ``/logout``. To do it, We will modify ``make_app()``:
+Once we have all handlers implemented, we need to tie them with URLs: ``/``, ``/login``, ``/logout``. To do it, we will modify ``make_app()``:
 
 .. code-block:: python
 

--- a/src/tornado/README.md
+++ b/src/tornado/README.md
@@ -1,0 +1,52 @@
+# tornado-globus
+Globus Authentication Handler for Tornado Web Framework and an example web app showing how to use the handler.
+
+## Install tornado-globus
+
+Create Python 3.x virtual environment and install Tornado
+```
+$ python --version
+Python 3.7.15
+$ python -mvenv  venv
+$ . venv/bin/activate
+$ pip install tornado
+```
+Download the tornado-globus sample app
+```
+(venv)$ git clone git@github.com:lukaszlacinski/tornado-globus.git
+(venv)$ cd tornado-globus
+```
+If you still use Tornado v5.x, go to `tornado_v5` directory.
+
+## Register a client
+
+All OAuth2 clients need to register with Globus Auth to get a client id and secret. 
+To register your client, go to `https://developers.globus.org/`, 
+click 'Register your app with Globus', add a new project and add a new app in the project. 
+Enter the name of your app you want to be shown to users when they are asked for a consent 
+when redirected to Globus Auth for authentication. Enter the redirect URI: 
+`https://example.com/auth/globus/`. Click 'Create App', click 'Generate New Client Secret' 
+and copy Client ID and the generated secret to `settings` in `app.py`.
+
+## Set up HTTPS reverse proxy
+
+Set up Apache, nginx or another HTTPS server as a reverse proxy to pass all requests to 
+`https://example.com/` to localhost:8888 where the app will be listening on.
+
+For example, on Ubuntu, add the following lines to /etc/apache2/sites-available/default-ssl.conf in `<VirtualHost _default_:443>`
+```
+        ProxyPass / http://127.0.0.1:8888/
+        ProxyPassReverse / http://127.0.0.1:8888/
+```
+Restart Apache.
+
+## Start the web app
+
+```
+(venv)$ python -m tornado.autoreload app.py
+```
+and open `https://example.com/` in a web browser. If you do not own `example.com` domain, you may need to add:
+```
+127.0.0.1 example.com
+```
+to your `/etc/hosts`.

--- a/src/tornado/app.py
+++ b/src/tornado/app.py
@@ -1,0 +1,82 @@
+import tornado.ioloop
+import tornado.web
+import globus
+
+
+class GlobusOAuth2LoginHandler(tornado.web.RequestHandler,
+                               globus.GlobusOAuth2Mixin):
+    async def get(self):
+        if self.get_argument("code", False):
+            tokens = await self.get_tokens(
+                redirect_uri=self.settings["globus_oauth"]["redirect_uri"],
+                code=self.get_argument("code"))
+            expires_at = int(time.time()) + tokens["expires_in"]
+            user_info = await self.get_user_info(tokens["access_token"])
+            # Save the user with e.g. set_secure_cookie
+            self.set_secure_cookie("user_id", user_info["sub"], expires=expires_at-60)
+            self.set_secure_cookie("username", user_info["preferred_username"])
+            self.set_secure_cookie("email", user_info["email"])
+            self.set_secure_cookie("name", user_info["name"])
+            self.set_secure_cookie("organization", user_info["organization"])
+            self.set_secure_cookie("access_token", tokens["access_token"])
+            self.set_secure_cookie("refresh_token", tokens["refresh_token"])
+            self.redirect("/")
+        else:
+            self.authorize_redirect(
+                redirect_uri=self.settings["globus_oauth"]["redirect_uri"],
+                client_id=self.settings["globus_oauth"]["key"],
+                scope=self.settings["globus_oauth"]["scope"],
+                response_type="code",
+                extra_params={"access_type": "offline"})
+
+
+class LogoutHandler(tornado.web.RequestHandler):
+    async def get(self):
+        self.clear_cookie("user_id")
+        self.redirect("/")
+
+
+class MainHandler(tornado.web.RequestHandler):
+    def get_current_user(self):
+        return self.get_secure_cookie("user_id")
+
+    def get(self):
+        self.render("home.html",
+                    user_id=self.current_user,
+                    username=self.get_secure_cookie("username"),
+                    email=self.get_secure_cookie("email"),
+                    name=self.get_secure_cookie("name"),
+                    organization=self.get_secure_cookie("organization"),
+                    access_token=self.get_secure_cookie("access_token"),
+                    refresh_token=self.get_secure_cookie("refresh_token"))
+
+
+def make_app():
+    settings = {
+        "cookie_secret": "32oETzKXQAGaYdkL5gEmGeJJFuYh7EQnp2XdTP1o/Vo=",
+        "xsrf_cookies": True,
+        "globus_oauth": {
+            "key": "<Globus_OAuth2_Client_Id>",
+            "secret": "<Globus_OAuth2_Client_Secret>",
+            "redirect_uri": "https://example.org/auth/globus",
+            "scope": [
+                "openid",
+                "profile",
+                "email",
+                "urn:globus:auth:scope:transfer.api.globus.org:all"
+            ]
+        }
+    }
+    handlers = [
+        (r"/", MainHandler),
+        (r"/login", GlobusOAuth2LoginHandler),
+        (r"/auth/globus", GlobusOAuth2LoginHandler),
+        (r"/logout", LogoutHandler),
+    ]
+    return tornado.web.Application(handlers, **settings)
+
+
+if __name__ == "__main__":
+    app = make_app()
+    app.listen(8888)
+    tornado.ioloop.IOLoop.instance().start()

--- a/src/tornado/globus.py
+++ b/src/tornado/globus.py
@@ -1,0 +1,42 @@
+import urllib.parse as urllib_parse
+from tornado import escape
+from tornado.auth import OAuth2Mixin
+
+
+class GlobusOAuth2Mixin(OAuth2Mixin):
+    _OAUTH_AUTHORIZE_URL = "https://auth.globus.org/v2/oauth2/authorize"
+    _OAUTH_ACCESS_TOKEN_URL = "https://auth.globus.org/v2/oauth2/token"
+    _OAUTH_USERINFO_URL = "https://auth.globus.org/v2/oauth2/userinfo"
+    _OAUTH_SETTINGS_KEY = "globus_oauth"
+
+    async def get_tokens(self, redirect_uri, code):
+        http = self.get_auth_http_client()
+        body = urllib_parse.urlencode({
+            "redirect_uri": redirect_uri,
+            "code": code,
+            "client_id": self.settings[self._OAUTH_SETTINGS_KEY]["key"],
+            "client_secret": self.settings[self._OAUTH_SETTINGS_KEY]["secret"],
+            "grant_type": "authorization_code"
+        })
+        response = await http.fetch(self._OAUTH_ACCESS_TOKEN_URL,
+                         method="POST",
+                         headers={"Content-Type": "application/x-www-form-urlencoded"},
+                         body=body)
+        return escape.json_decode(response.body)
+
+    def get_user_info(self, access_token):
+        return self.oauth2_request(self._OAUTH_USERINFO_URL,
+                                   access_token=access_token)
+
+    async def oauth2_request(self, url, access_token=None, post_args=None, *args):
+        headers = {}
+        if access_token:
+            headers = {"Authorization": "Bearer " + access_token}
+        if args:
+            url += "?" + urllib_parse.urlencode(args)
+        http = self.get_auth_http_client()
+        if post_args is not None:
+            response = await http.fetch(url, method="POST", headers=headers, body=urllib_parse.urlencode(post_args))
+        else:
+            response = await http.fetch(url, headers=headers)
+        return escape.json_decode(response.body)

--- a/src/tornado/home.html
+++ b/src/tornado/home.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Tornado Web App</title>
+</head>
+<body>
+    <div>
+    <h1>Tornado web app with authentication delegated to Globus Auth</h1>
+    <p>
+         <br/>
+        {% if user_id %}
+        Hello {{ name }}!<br/>
+        &nbsp; Username: {{ username }}<br/>
+        &nbsp; Email: {{ email }}<br/>
+        &nbsp; UUID: {{ user_id }}<br/>
+        &nbsp; Organization: {{ organization }}<br/>
+        &nbsp; Access token: {{ access_token }}<br/>
+        &nbsp; Refresh token: {{ refresh_token }}<br/>
+        <br/>
+        <a href="/logout">Logout</a>
+        {% else %}
+        <a href="/login">Login to Globus</a>
+        {% end %}
+    </p>
+    </div>
+</body>
+</html>

--- a/src/tornado/tornado_v5/app.py
+++ b/src/tornado/tornado_v5/app.py
@@ -1,0 +1,82 @@
+import tornado.ioloop
+import tornado.web
+import globus
+
+
+class GlobusOAuth2LoginHandler(tornado.web.RequestHandler,
+                               globus.GlobusOAuth2Mixin):
+    async def get(self):
+        if self.get_argument("code", False):
+            tokens = await self.get_tokens(
+                redirect_uri=self.settings["globus_oauth"]["redirect_uri"],
+                code=self.get_argument("code"))
+            expires_at = int(time.time()) + tokens["expires_in"]
+            user_info = await self.get_user_info(tokens["access_token"])
+            # Save the user with e.g. set_secure_cookie
+            self.set_secure_cookie("user_id", user_info["sub"], expires=expires_at-60)
+            self.set_secure_cookie("username", user_info["preferred_username"])
+            self.set_secure_cookie("email", user_info["email"])
+            self.set_secure_cookie("name", user_info["name"])
+            self.set_secure_cookie("organization", user_info["organization"])
+            self.set_secure_cookie("access_token", tokens["access_token"])
+            self.set_secure_cookie("refresh_token", tokens["refresh_token"])
+            self.redirect("/")
+        else:
+            await self.authorize_redirect(
+                redirect_uri=self.settings["globus_oauth"]["redirect_uri"],
+                client_id=self.settings["globus_oauth"]["key"],
+                scope=self.settings["globus_oauth"]["scope"],
+                response_type="code",
+                extra_params={"access_type": "offline"})
+
+
+class LogoutHandler(tornado.web.RequestHandler):
+    async def get(self):
+        self.clear_cookie("user_id")
+        self.redirect("/")
+
+
+class MainHandler(tornado.web.RequestHandler):
+    def get_current_user(self):
+        return self.get_secure_cookie("user_id")
+
+    def get(self):
+        self.render("../home.html",
+                    user_id=self.current_user,
+                    username=self.get_secure_cookie("username"),
+                    email=self.get_secure_cookie("email"),
+                    name=self.get_secure_cookie("name"),
+                    organization=self.get_secure_cookie("organization"),
+                    access_token=self.get_secure_cookie("access_token"),
+                    refresh_token=self.get_secure_cookie("refresh_token"))
+
+
+def make_app():
+    settings = {
+        "cookie_secret": "32oETzKXQAGaYdkL5gEmGeJJFuYh7EQnp2XdTP1o/Vo=",
+        "xsrf_cookies": True,
+        "globus_oauth": {
+            "key": "<Globus_OAuth2_Client_Id>",
+            "secret": "<Globus_OAuth2_Client_Secret>",
+            "redirect_uri": "https://example.org/auth/globus",
+            "scope": [
+                "openid",
+                "profile",
+                "email",
+                "urn:globus:auth:scope:transfer.api.globus.org:all"
+            ]
+        }
+    }
+    handlers = [
+        (r"/", MainHandler),
+        (r"/login", GlobusOAuth2LoginHandler),
+        (r"/auth/globus", GlobusOAuth2LoginHandler),
+        (r"/logout", LogoutHandler),
+    ]
+    return tornado.web.Application(handlers, **settings)
+
+
+if __name__ == "__main__":
+    app = make_app()
+    app.listen(8888)
+    tornado.ioloop.IOLoop.instance().start()

--- a/src/tornado/tornado_v5/globus.py
+++ b/src/tornado/tornado_v5/globus.py
@@ -1,0 +1,61 @@
+import functools
+import urllib.parse as urllib_parse
+from tornado import escape
+from tornado.concurrent import future_set_result_unless_cancelled
+from tornado.stack_context import wrap
+from tornado.auth import OAuth2Mixin
+from tornado.auth import _auth_return_future
+
+
+class GlobusOAuth2Mixin(OAuth2Mixin):
+    _OAUTH_AUTHORIZE_URL = "https://auth.globus.org/v2/oauth2/authorize"
+    _OAUTH_ACCESS_TOKEN_URL = "https://auth.globus.org/v2/oauth2/token"
+    _OAUTH_USERINFO_URL = "https://auth.globus.org/v2/oauth2/userinfo"
+    _OAUTH_SETTINGS_KEY = "globus_oauth"
+
+    @_auth_return_future
+    def get_tokens(self, redirect_uri, code, callback):
+        http = self.get_auth_http_client()
+        body = urllib_parse.urlencode({
+            "redirect_uri": redirect_uri,
+            "code": code,
+            "client_id": self.settings[self._OAUTH_SETTINGS_KEY]["key"],
+            "client_secret": self.settings[self._OAUTH_SETTINGS_KEY]["secret"],
+            "grant_type": "authorization_code"
+        })
+        fut = http.fetch(self._OAUTH_ACCESS_TOKEN_URL,
+                         method="POST",
+                         headers={"Content-Type": "application/x-www-form-urlencoded"},
+                         body=body)
+        fut.add_done_callback(wrap(functools.partial(self._on_access_token, callback)))
+
+    def _on_access_token(self, future, response_fut):
+        """Callback function for the exchange to the access token."""
+        try:
+            response = response_fut.result()
+        except Exception as e:
+            future.set_exception(AuthError('Globus auth error: %s' % str(e)))
+            return
+
+        args = escape.json_decode(response.body)
+        future_set_result_unless_cancelled(future, args)
+
+    def get_user_info(self, access_token):
+        return self.oauth2_request(self._OAUTH_USERINFO_URL,
+                                   access_token=access_token)
+
+    @_auth_return_future
+    def oauth2_request(self, url, callback, access_token=None,
+                       post_args=None, *args):
+        headers = {}
+        if access_token:
+            headers = {"Authorization": "Bearer " + access_token}
+        if args:
+            url += "?" + urllib_parse.urlencode(args)
+        callback = wrap(functools.partial(self._on_oauth2_request, callback))
+        http = self.get_auth_http_client()
+        if post_args is not None:
+            fut = http.fetch(url, method="POST", headers=headers, body=urllib_parse.urlencode(post_args))
+        else:
+            fut = http.fetch(url, headers=headers)
+        fut.add_done_callback(callback)


### PR DESCRIPTION
The example shows how to implement GlobusOAuth2Mixin (a class that inherits from tornado.auth.OAuth2Mixin) and use the mixin to implement GlobusOAuth2Handler in a simple app that takes all benefits of Tornado non-blocking I/O.